### PR TITLE
Do not error for 500 or 524 errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,6 +187,7 @@ of the Definitely Typed header to
  */
 function checkSource(name, dts, src) {
     if (dts.indexOf("export default") > -1 && !/declare module ['"]/.test(dts) &&
+        src.indexOf("524: A timeout occurred") === -1 && src.indexOf("500 Server Error") === -1 &&
         !isRealExportDefault(name) && src.indexOf("default") === -1 && src.indexOf("__esModule") === -1 && src.indexOf("react-side-effect") === -1 && src.indexOf("@flow") === -1 && src.indexOf("module.exports = require") === -1) {
         throw new Error(`The types for ${name} specify 'export default' but the source does not mention 'default' anywhere.
 Here is the source:

--- a/index.test.js
+++ b/index.test.js
@@ -175,4 +175,16 @@ suite("checkSource", {
             `module.exports = function () {};`)).toThrow(
                 "The types for foo specify 'export default' but the source does not mention 'default' anywhere.");
     },
+    serverError500() {
+        expect(checkSource(
+            "foo",
+            `function f() {}; export default f;`,
+            `<title>500 Server Error</title>`)).toBeUndefined();
+    },
+    serverError524() {
+        expect(checkSource(
+            "foo",
+            `function f() {}; export default f;`,
+            `<title>unpkg.com | 524: A timeout occurred</title>`)).toBeUndefined();
+    },
 });


### PR DESCRIPTION
I'm pretty sure unpkg is throttling us (which is justified), and the easiest thing to do is to not issue an error in that case.