### PR TITLE
Remove unneeded trailing comma

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ if (!module.parent) {
 
 function main() {
     const argv = yargs.
-        usage("$0 name.d.ts [source-folder]\n\nIf source-folder is not provided, I will look for a matching package on npm.", ).
+        usage("$0 name.d.ts [source-folder]\n\nIf source-folder is not provided, I will look for a matching package on npm.").
         help().
         argv;
     if (argv._.length === 0) {


### PR DESCRIPTION
The trailing comma that was on L51 started to fail our builds over on unifiedjs/unified on Node lts/boron as we use dtslint, but this didn’t happen in a semver major release.
As the rest of the code here does not use trailing commas in arguments, I believe it’s unneeded, so I hope you accept this PR fixing support on older Node versions.